### PR TITLE
Add decision publish from policy engine

### DIFF
--- a/policy_engine/policy_checker.py
+++ b/policy_engine/policy_checker.py
@@ -32,6 +32,11 @@ class PolicyChecker:
         topic = "action/allowed" if allowed else "action/blocked"
         log.info(f"{topic}: {payload['action']}")
         self.bus.publish(topic, payload)
+        # emit a generic decision event for UI updates and auditing
+        self.bus.publish(
+            "action/decision",
+            {"action": payload.get("action"), "allow": allowed},
+        )
 
     def check(self, activity: str, confidence: float) -> bool:
         rule = self.rules.get(activity)

--- a/protection_layer/enforcement.py
+++ b/protection_layer/enforcement.py
@@ -26,6 +26,15 @@ class Enforcement:
     def _handle_allowed(self, _topic: str, payload: Dict) -> None:
         log.info(f"Enforcing {payload['action']}")
         enforce(payload["action"], payload)
+        # notify other components of the decision
+        self.bus.publish(
+            "action/decision",
+            {"action": payload.get("action"), "allow": True},
+        )
 
     def _handle_blocked(self, _topic: str, payload: Dict) -> None:
         log.info(f"Blocked {payload['action']}")
+        self.bus.publish(
+            "action/decision",
+            {"action": payload.get("action"), "allow": False},
+        )


### PR DESCRIPTION
## Summary
- emit `action/decision` after evaluating action requests
- enforcement layer now also publishes `action/decision`
- dashboard already listens for this topic and updates accordingly

## Testing
- `pytest -q`
- `python main.py & pid=$!; sleep 3; curl -s http://127.0.0.1:5000/api/status; echo; sleep 1; curl -s http://127.0.0.1:5000/api/status; echo; kill $pid`


------
https://chatgpt.com/codex/tasks/task_e_684879a400c083268adea9a394a311c1