### PR TITLE
Fix policy loader crash

### DIFF
--- a/policy_engine/policy_checker.py
+++ b/policy_engine/policy_checker.py
@@ -1,14 +1,79 @@
-"""Simple policy checker."""
+"""Policy checker used to approve or block detected activities."""
 
-from typing import Dict
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+from utils.event_bus import EventBus
 
 
 class PolicyChecker:
-    def __init__(self, rules: Dict):
-        self.rules = rules
+    """Validate activities against policy thresholds."""
 
+    def __init__(
+        self,
+        bus: Optional[EventBus] = None,
+        rules: Optional[Dict[str, Dict[str, Any]]] = None,
+        rules_path: str = "policy_engine/policy_rules.json",
+    ) -> None:
+        """Create a new ``PolicyChecker``.
+
+        Parameters
+        ----------
+        bus:
+            ``EventBus`` used to subscribe to activity events. If ``None`` the
+            checker works as a simple helper without bus integration.
+        rules:
+            Optional rules dictionary. If omitted ``rules_path`` will be loaded
+            instead.
+        rules_path:
+            Path to a JSON rules file. Ignored when ``rules`` is provided.
+        """
+
+        self.bus = bus
+        self.rules: Dict[str, Dict[str, Any]] = (
+            rules if rules is not None else self._load_rules(rules_path)
+        )
+
+        if self.bus is not None:
+            self.bus.subscribe("activity/detected", self._on_activity)
+
+    # ------------------------------------------------------------------
+    def _load_rules(self, path: str) -> Dict[str, Dict[str, Any]]:
+        """Load policy rules from ``path``.
+
+        The JSON may optionally wrap the actual policies in a top-level
+        ``"policies"`` key. Each policy must contain a numeric ``threshold``
+        value.
+        """
+
+        with open(path) as fh:
+            data = json.load(fh)
+
+        if "policies" in data and isinstance(data["policies"], dict):
+            data = data["policies"]
+
+        rules: Dict[str, Dict[str, Any]] = {}
+        for act, rule in data.items():
+            threshold = rule.get("threshold")
+            if not isinstance(threshold, (int, float)):
+                raise ValueError(f"Policy for '{act}' missing numeric 'threshold'")
+            rules[act] = {"threshold": float(threshold)}
+        return rules
+
+    # ------------------------------------------------------------------
+    def _on_activity(self, _topic: str, payload: Dict[str, Any]) -> None:
+        activity = payload.get("activity")
+        confidence = payload.get("confidence", 0.0)
+        if self.check(activity, confidence):
+            self.bus.publish("policy/allowed", payload)
+        else:
+            self.bus.publish("policy/blocked", payload)
+
+    # ------------------------------------------------------------------
     def check(self, activity: str, confidence: float) -> bool:
         rule = self.rules.get(activity)
         if not rule:
             return False
-        return confidence >= rule.get("threshold", 1.0)
+        return confidence >= rule["threshold"]

--- a/user_interface/app.py
+++ b/user_interface/app.py
@@ -14,7 +14,7 @@ def load_rules(path: str):
 
 def main():
     rules = load_rules("policy_engine/policy_rules.json")
-    checker = policy_checker.PolicyChecker(rules)
+    checker = policy_checker.PolicyChecker(rules=rules)
 
     temp = temp_sensor.read_temperature()
     motion = motion_sensor.motion_detected()


### PR DESCRIPTION
## Summary
- implement a more robust `PolicyChecker` that can load rules from file
- handle optional `policies` wrapper in JSON config
- update CLI demo to use new `PolicyChecker`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849954759488326a62dde93abe8757b